### PR TITLE
add a custom event called tab-selected when the selected item changes

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -38,6 +38,12 @@ To change the sliding bar color:
 @extends core-selector
 @homepage github.io
 -->
+<!--
+Fired when the selected tab is changed. This event's srcElement and target is the selected
+tab in the list.
+
+@event tab-selected
+-->
 
 <link rel="import" href="../core-selector/core-selector.html">
 <link rel="import" href="paper-tab.html">
@@ -80,6 +86,10 @@ To change the sliding bar color:
     activateEvent: 'down',
     
     nostretch: false,
+
+    selectedChanged: function () {
+      this.fire('tab-selected', {value:this.selectedItem});
+    },
     
     selectedIndexChanged: function(old) {
       var s = this.$.selectionBar.style;


### PR DESCRIPTION
Using the "core-select" event on paper-tabs yields 2 events (one for the unselected element and one for the newly selected element), which is unexpected. Instead I've added a "tab-selected" event that is fired when the selected item is changed (where the target element is the newly selected tab). This gives me the result I expect, one event with the newly selected tab's element in the event.
