### PR TITLE
Add default width

### DIFF
--- a/paper-tabs.css
+++ b/paper-tabs.css
@@ -13,6 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   font-size: 14px;
   font-weight: 500;
   height: 48px;
+  width: 100%;
   overflow: hidden;
 }
 


### PR DESCRIPTION
This adds a default `width` of `100%` to `paper-tabs` so they fill whatever container they're placed inside of. `paper-tabs` already has a default `height`, but no default `width`, and that can be a stumbling block for developers, especially those new to Polymer, who expect to see something when they use the tag. @frankiefu wdyt?
