### PR TITLE
Default user-select to none

### DIFF
--- a/paper-tabs.css
+++ b/paper-tabs.css
@@ -14,6 +14,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   font-weight: 500;
   height: 48px;
   overflow: hidden;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 #tabsContainer {


### PR DESCRIPTION
I think in most use cases you don't want the text inside of tabs to be selectable, they should just act like buttons
