### PR TITLE
Fix flickering scroll buttons on wide windows.

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -230,7 +230,7 @@ To change the ink ripple color:
       var tc = this.$.tabsContainer;
       var l = tc.scrollLeft;
       this.leftHidden = l === 0;
-      this.rightHidden = l === (tc.scrollWidth - tc.clientWidth);
+      this.rightHidden = l === Math.max(0, (tc.scrollWidth - tc.clientWidth));
     },
     
     holdLeft: function() {


### PR DESCRIPTION
On Chrome 39, at least, I've found that tc.scrollWidth < tc.clientWidth
in some cases when the tabs container is very wide. This might just be
due to properties not updating fast enough when resizing, but clamping
the value to zero or greater solves the problem.