### PR TITLE
Scroll to selected if needed even when initialising

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -296,6 +296,7 @@ To change the ink ripple color:
       
       if (this.noslide || old == null) {
         this.positionBarForSelected();
+        this.scrollToSelectedIfNeeded();
         return;
       }
       


### PR DESCRIPTION
When setting an initial tab to one which is out of view, the scroll area is not automatically moved.
